### PR TITLE
Support for HTML5 compliant form errors ( was BitBucket)

### DIFF
--- a/formencode/htmlfill.py
+++ b/formencode/htmlfill.py
@@ -325,6 +325,8 @@ class FillingParser(RewritingParser):
             self.handle_end_textarea()
         elif tag == 'select':
             self.handle_end_select()
+        elif tag == 'form:error':
+            self.handle_end_error()
         elif tag == 'form:iferror':
             self.handle_end_iferror()
 
@@ -365,6 +367,9 @@ class FillingParser(RewritingParser):
             self.write_text(error)
         self.skip_next = True
         self.used_errors.add(name)
+
+    def handle_end_error(self):
+        self.skip_next = True
 
     def handle_input(self, attrs, startend):
         t = (self.get_attr(attrs, 'type') or 'text').lower()

--- a/tests/test_htmlfill.py
+++ b/tests/test_htmlfill.py
@@ -149,6 +149,19 @@ def test_iferror():
         assert str(e) == "Name attribute in <iferror> required at 1:0"
 
 
+def test_error():
+    # classic
+    assert ( htmlfill.render('<form:error name="field1"/>', errors={'field1': 'foo'} )
+            == '<span class="error-message">foo</span><br />\n')
+    assert ( htmlfill.render('<form:error name="field1"/><a href="#">Next Tag</a>', errors={'field1': 'foo'} )
+            == '<span class="error-message">foo</span><br />\n<a href="#">Next Tag</a>')
+    # html5
+    assert ( htmlfill.render('<form:error name="field1"></form:error>', errors={'field1': 'foo'} )
+            == '<span class="error-message">foo</span><br />\n')
+    assert ( htmlfill.render('<form:error name="field1"></form:error><a href="#">Next Tag</a>', errors={'field1': 'foo'} )
+            == '<span class="error-message">foo</span><br />\n<a href="#">Next Tag</a>')
+
+
 def test_literal():
     assert (htmlfill.render('<form:error name="foo" />',
                             errors={'foo': htmlfill.htmlliteral('<test>')})


### PR DESCRIPTION
- supports non-selfclosing form:error tags "<form:error name='a'>/form:error"
- tests added to ensure backwards compliance of 'classic' self-closing tags , and new non-selfclosing tags.
- tests also check to ensure the following tag is not affected

Recap:
On the html5 spec, only a subset of tags - void , svg, and math - are allowed to be self-closing. The rest are expected to close. [ http://www.w3.org/TR/html5/syntax.html#void-elements ]

The issue is that (according to the specs) while <form:error /> is valid for XHTML it is invalid for HTML5 . form:error/form:error should work on both.

This is only an issue if you're not parsing the original state of the form with htmlfill , or if you're having a front-end team mark up standalone html pages before passing off to the backend -- but it can pop up.
