### PR TITLE
Change setup.py URL to github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ FormEncode validates and converts nested structures.  It allows for
 a declarative form of defining the validation, and decoupled processes
 for filling and generating forms.
 
-The official repo is at BitBucket: https://bitbucket.org/formencode/official-formencode/
+The official repo is at GitHub: https://github.com/formencode/formencode
 """,
       classifiers=["Development Status :: 4 - Beta",
                    "Intended Audience :: Developers",


### PR DESCRIPTION
Currently, setup.py still refers to the old bitbucket URL. This pull request changes that to github.
