### PR TITLE
Invalid keys shouldn't cause a crash

### DIFF
--- a/formencode/variabledecode.py
+++ b/formencode/variabledecode.py
@@ -45,6 +45,8 @@ def variable_decode(d, dict_char='.', list_char='-'):
                 break
             elif list_char in key:
                 key, index = key.split(list_char)
+                if not index.isdigit():
+                    continue
                 new_keys.append(key)
                 dicts_to_sort.add(tuple(new_keys))
                 new_keys.append(int(index))


### PR DESCRIPTION
Keys of the form name-notdigits will cause the validation to crash.

In theory this is a security issue because an attacker could submit an
arbitrary form with keys in this format.

Not sure if this is the correct way to solve the problem, though.
