### PR TITLE
tox.ini: Test more environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27
+envlist=py26,py27,pypy,py33,py34
 
 [testenv]
 deps=nose
@@ -7,3 +7,18 @@ deps=nose
     pycountry
 commands=nosetests
 
+[testenv:py33]
+deps=nose
+    dnspython3
+    pycountry
+# Need to run nosetests in a different directory so it picks up 2to3-translated
+# files and not the untranslated files in the source directory
+commands=nosetests -w /tmp formencode
+
+[testenv:py34]
+deps=nose
+    dnspython3
+    pycountry
+# Need to run nosetests in a different directory so it picks up 2to3-translated
+# files and not the untranslated files in the source directory
+commands=nosetests -w /tmp formencode


### PR DESCRIPTION
This augments the `tox.ini` so that a bunch more environments are tested, which is what tox is good for!

```
marca@marca-mac:~/dev/git-repos/formencode$ tox
GLOB sdist-make: /Users/marca/dev/git-repos/formencode/setup.py
py26 inst-nodeps: /Users/marca/dev/git-repos/formencode/.tox/dist/FormEncode-1.3.0dev.zip
py26 runtests: commands[0] | nosetests
...............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 239 tests in 3.927s

OK
py27 inst-nodeps: /Users/marca/dev/git-repos/formencode/.tox/dist/FormEncode-1.3.0dev.zip
py27 runtests: commands[0] | nosetests
...............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 239 tests in 2.226s

OK
pypy inst-nodeps: /Users/marca/dev/git-repos/formencode/.tox/dist/FormEncode-1.3.0dev.zip
pypy runtests: commands[0] | nosetests
...............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 239 tests in 4.142s

OK
py33 inst-nodeps: /Users/marca/dev/git-repos/formencode/.tox/dist/FormEncode-1.3.0dev.zip
py33 runtests: commands[0] | nosetests -w /tmp formencode
...............................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 239 tests in 0.745s

OK
py34 inst-nodeps: /Users/marca/dev/git-repos/formencode/.tox/dist/FormEncode-1.3.0dev.zip
py34 runtests: commands[0] | nosetests -w /tmp formencode
.................................../Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/socket.py:444: ResourceWarning: unclosed <socket.socket fd=8, family=2, type=1, proto=6, laddr=('127.0.0.1', 50123), raddr=('74.125.239.102', 80)>
  self._sock = None
/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/socket.py:444: ResourceWarning: unclosed <socket.socket fd=8, family=2, type=1, proto=6, laddr=('127.0.0.1', 50125), raddr=('162.209.98.227', 80)>
  self._sock = None
............................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 239 tests in 0.841s

OK
_________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  congratulations :)
```
