### PR TITLE
Variables with two dashes cause variable decode to crash.

### DIFF
--- a/formencode/variabledecode.py
+++ b/formencode/variabledecode.py
@@ -44,7 +44,7 @@ def variable_decode(d, dict_char='.', list_char='-'):
                 was_repetition_count = True
                 break
             elif list_char in key:
-                maybe_key, index = key.split(list_char)
+                maybe_key, index = key.split(list_char, 1)
                 if not index.isdigit():
                     new_keys.append(key)
                 else:


### PR DESCRIPTION
This stops the variable decoder from crashing when a form variable contains a second dash.
