### PR TITLE
Fixed #57. Ignore tags within a textarea while parsing.

### DIFF
--- a/formencode/htmlfill.py
+++ b/formencode/htmlfill.py
@@ -312,7 +312,13 @@ class FillingParser(RewritingParser):
 
     def handle_starttag(self, tag, attrs, startend=False):
         self.write_pos()
-        if tag == 'input':
+        if self.in_textarea:
+            # Ignore all tags within a textarea. All content within a
+            # textarea is considered as value and not as part of
+            # the form which should be prefilled by htmlfill. So leave
+            # the value as it is.
+            return
+        elif tag == 'input':
             self.handle_input(attrs, startend)
         elif tag == 'textarea':
             self.handle_textarea(attrs)


### PR DESCRIPTION
Hi, tried to provide a simple fix for #56. It solves my problem. As the code already seems to be aware of beeing inside a textarea I simply used to flag "self.in_textarea" to ignore all tags within a textfield.

regards 
