### PR TITLE
Added a test to TestURLValidator that fails (but should not).

### DIFF
--- a/formencode/tests/test_validators.py
+++ b/formencode/tests/test_validators.py
@@ -704,6 +704,10 @@ class TestURLValidator(unittest.TestCase):
             "http://65.18.195.155/cgi-ordoro/bo/start.cgi"),
             "http://65.18.195.155/cgi-ordoro/bo/start.cgi")
 
+    def test_invalid_url(self):
+        self.assertRaises(validators.Invalid, self.validator.to_python,
+            '[http://domain.co.jp')
+
 
 class TestRequireIfMissingValidator(unittest.TestCase):
 

--- a/formencode/validators.py
+++ b/formencode/validators.py
@@ -1527,8 +1527,11 @@ class URL(FancyValidator):
         global urlparse
         if urlparse is None:
             import urlparse
-        scheme, netloc, path, params, query, fragment = urlparse.urlparse(
-            url)
+        try:
+            scheme, netloc, path, params, query, fragment = urlparse.urlparse(
+                url)
+        except ValueError:
+            return url
         try:
             netloc = netloc.encode('idna')
             if unicode is str:  # Python 3


### PR DESCRIPTION
An invalid URL should be reported as an Invalid exception. However, it is reported as ValueError. The URL in the test case starts with the invalid character '['.