### PR TITLE
can't build universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,5 +26,5 @@ output_dir = formencode/i18n
 previous = true
 
 [wheel]
-universal = 1
+universal = 0
 


### PR DESCRIPTION
Present setup.cfg is marked universal flag in wheel section.
Therefore, setup.py generates universal (= python2/3 compatible) wheel.

```
$ python --version
Python 2.7.10
$ python setup.py bdist_wheel
$ ls dist
FormEncode-1.3.0-py2.py3-none-any.whl
```

However, this package can't work in python3.
It throws an exception when imported.

```
$ python --version
Python 3.5.0
$ pip install dist/FormEncode-1.3.0-py2.py3-none-any.whl
Processing ./dist/FormEncode-1.3.0-py2.py3-none-any.whl
Installing collected packages: FormEncode
Successfully installed FormEncode-1.3.0
$ (cd; python -c "import formencode")
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/satoshi-k/.virtualenvs/py35/lib/python3.5/site-packages/formencode/__init__.py", line 3, in <module>
    from formencode.api import (
  File "/Users/satoshi-k/.virtualenvs/py35/lib/python3.5/site-packages/formencode/api.py", line 109, in <module>
    class Invalid(Exception):
  File "/Users/satoshi-k/.virtualenvs/py35/lib/python3.5/site-packages/formencode/api.py", line 153, in Invalid
    if unicode is not str:  # Python 2
NameError: name 'unicode' is not defined
```

It is because 2to3 is not applied when building.
But this issue is not resolved even if 2to3 is applied.
An applied package can't work in python2.

The setting and behavior don't match at present.
So we turn off universal flag in setup.cfg.