### PR TITLE
Add python 3.5 to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 
 install: pip install .


### PR DESCRIPTION
Waiting on successful travis build for merge, fixes #95.