### PR TITLE
Handle the case when '[]' is in a parameter name (JQuery)

### DIFF
--- a/formencode/schema.py
+++ b/formencode/schema.py
@@ -4,6 +4,7 @@ import warnings
 from .api import _, is_validator, FancyValidator, Invalid, NoDefault
 from . import declarative
 from .exc import FERuntimeWarning
+from .validators import Set
 import six
 from six.moves import map
 from six.moves import zip
@@ -93,7 +94,13 @@ class Schema(FancyValidator):
                     warnings.warn(msg, FERuntimeWarning)
                 continue
             if is_validator(value):
-                cls.fields[key] = value
+                # JQuery adds a '[]' to the key name of a
+                # parameter that is an array. ( field_name = key + '[]' )
+                if isinstance(value, Set) and \
+                        getattr(value, "array_in_field_name", False):
+                    cls.fields[key + "[]"] = value
+                else:
+                    cls.fields[key] = value
                 delattr(cls, key)
             # This last case means we're overwriting a validator
             # from a superclass:

--- a/formencode/validators.py
+++ b/formencode/validators.py
@@ -1203,6 +1203,10 @@ class Set(FancyValidator):
     If you give ``use_set=True``, then it will return an actual
     ``set`` object.
 
+    If you give ``array_in_field_name=True``, then a '[]' string will be
+    appended to the end of the field name. JQuery appends a '[]' to the end
+    of a parameter name when the value is an array.
+
     ::
 
        >>> Set.to_python(None)
@@ -1221,6 +1225,7 @@ class Set(FancyValidator):
     """
 
     use_set = False
+    array_in_field_name = False
 
     if_missing = ()
     accept_iterator = True
@@ -2340,7 +2345,7 @@ class ISODateTimeConverter(FancyValidator):
     """
     Converts fields which contain both date and time, in the
     ISO 8601 standard format YYYY-MM-DDTHH:MM:SS.
-    
+
     Stores in a datetime.datetime object.
 
     Examples::
@@ -2356,10 +2361,10 @@ class ISODateTimeConverter(FancyValidator):
         Invalid: The must enter your date & time in the format YYYY-MM-DDTHH:MM:SS
 
     """
-    
+
     # This can be set to make it prefer mxDateTime:
     datetime_module = None
-    
+
     messages = dict(
         invalidFormat=_('The must enter your date & time in the format YYYY-MM-DDTHH:MM:SS'),)
 


### PR DESCRIPTION
JQuery appends a '[]' string to the end of a parameter name when the value is an array. 
For example:

``` javascript
$.ajax({
  method: "POST",
  url: "fake_endpoint",
  data: {
    settings: [ 1, 2, 3, 4, 5]
  }
})
```

Will turn the settings param name into `settings[]`

Allow for the schema to handle this case appropriate with by specifying that this is the case with an 'array_in_field_name' boolean.
