### PR TITLE
Fix a collection of errors from msgfmt.

### DIFF
--- a/formencode/i18n/it/LC_MESSAGES/FormEncode.po
+++ b/formencode/i18n/it/LC_MESSAGES/FormEncode.po
@@ -440,7 +440,7 @@ msgstr "Inserire i minuti ( dopo i : )"
 #: formencode/validators.py:2075
 #, python-format
 msgid "The %(part)s value you gave is not a number: %(number)r"
-msgstr "%(part), non e' un numero: %(number)r"
+msgstr "%(part)s, non e' un numero: %(number)r"
 
 #: formencode/validators.py:2076
 #, python-format

--- a/formencode/i18n/ja/LC_MESSAGES/FormEncode.po
+++ b/formencode/i18n/ja/LC_MESSAGES/FormEncode.po
@@ -494,7 +494,7 @@ msgstr ""
 #: formencode/validators.py:2586
 #, python-format
 msgid "You must give a value for %s"
-msgstr "% の値を入力してください"
+msgstr "%s の値を入力してください"
 
 #: formencode/validators.py:2619
 #, python-format

--- a/formencode/i18n/ko/LC_MESSAGES/FormEncode.po
+++ b/formencode/i18n/ko/LC_MESSAGES/FormEncode.po
@@ -327,7 +327,7 @@ msgstr "올바른 URL이 아닙니다"
 #: formencode/validators.py:1455
 #, python-format
 msgid "An error occurred when trying to access the URL: %(error)s"
-msgstr "URL에 접속 시도중 오류가 발생했습니다: $(error)s"
+msgstr "URL에 접속 시도중 오류가 발생했습니다: %(error)s"
 
 #: formencode/validators.py:1459
 msgid "The server responded that the page could not be found"

--- a/formencode/i18n/nl/LC_MESSAGES/FormEncode.po
+++ b/formencode/i18n/nl/LC_MESSAGES/FormEncode.po
@@ -292,7 +292,7 @@ msgstr ""
 msgid ""
 "The username portion of the email address is invalid (the portion before the "
 "@: %(username)s)"
-msgstr "Ongeldig emailadres: het deel vóór de \"@\" is incorrect"
+msgstr "Ongeldig emailadres: het deel vóór de \"@: %(username)s\" is incorrect"
 
 #: formencode/validators.py:1271 formencode/validators.py:1413
 #, python-format
@@ -305,7 +305,8 @@ msgid ""
 "The domain portion of the email address is invalid (the portion after the @: "
 "%(domain)s)"
 msgstr ""
-"Ongeldig emailadres: het \"domain\" (het deel achter de \"@\") is incorrect"
+"Ongeldig emailadres: het \"domain\" (het deel achter de \"@: %(domain)s\") "
+"is incorrect"
 
 #: formencode/validators.py:1275
 #, python-format
@@ -313,7 +314,8 @@ msgid ""
 "The domain of the email address does not exist (the portion after the @: "
 "%(domain)s)"
 msgstr ""
-"Ongeldig emailadres: het \"domain\" (het deel achter de \"@\") bestaat niet"
+"Ongeldig emailadres: het \"domain\" (het deel achter de \"@: %(domain)s\") "
+"bestaat niet"
 
 #: formencode/validators.py:1409
 msgid "You must start your URL with http://, https://, etc"

--- a/formencode/i18n/sl/LC_MESSAGES/FormEncode.po
+++ b/formencode/i18n/sl/LC_MESSAGES/FormEncode.po
@@ -302,8 +302,6 @@ msgstr "Domenski del e-poštnega naslova je neveljaven: %(domain)s"
 
 #: formencode/validators.py:1275
 #, fuzzy, python-format
-#| msgid "" "The domain portion of the email address is invalid (the portion
-#| after the" " @: %(domain)s)"
 msgid ""
 "The domain of the email address does not exist (the portion after the @: "
 "%(domain)s)"

--- a/formencode/i18n/sv/LC_MESSAGES/FormEncode.po
+++ b/formencode/i18n/sv/LC_MESSAGES/FormEncode.po
@@ -118,7 +118,7 @@ msgstr "Det språket inte är upptaget i ISO 639"
 #: formencode/schema.py:68
 #, python-format
 msgid "The input field %(name)s was not expected."
-msgstr "Inmatningsfältet %(namn) var inte förväntat."
+msgstr "Inmatningsfältet %(name)s var inte förväntat."
 
 #: formencode/schema.py:69
 msgid "Missing value"
@@ -331,7 +331,7 @@ msgstr ""
 #: formencode/validators.py:1461
 #, python-format
 msgid "You must provide a full domain name (like %(domain)s.com)"
-msgstr "Du måste ange ett komplett domännamn (som %(domän)er.com"
+msgstr "Du måste ange ett komplett domännamn (som %(domain)s.com"
 
 #: formencode/validators.py:1602
 msgid ""


### PR DESCRIPTION
Fix a number of minor issues that msgfmt marks as errors. This includes
missing format specifiers, invalid format strings due to translating the
substiution name and typos in the translated format string.