### PR TITLE
Bugfix/validator message

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ The latest documentation is available at http://www.formencode.org/
 Testing
 -------
 
-Use `python setup.py nosetests` to run the test suite.
-Use `tox` to run the test suite for all supported Python versions.
+Use :code:`python setup.py test` to run the test suite.
+Use :code:`tox` to run the test suite for all supported Python versions.
 
 
 Changes

--- a/formencode/tests/test_validators.py
+++ b/formencode/tests/test_validators.py
@@ -799,3 +799,21 @@ class TestCondfirmType(unittest.TestCase):
         self.assertEqual(value, validator.to_python(value))
 
         self.assertRaises(validators.Invalid, validator.to_python, ({'bar': {}},))
+
+
+class TestPlainTextValidator(unittest.TestCase):
+
+    def test_valid_text(self):
+        validator = validators.PlainText()
+        value = 'foo-Bar_123'
+        self.assertEqual(value, validator.to_python(value))
+
+    def test_invalid_text(self):
+        validator = validators.PlainText()
+        invalid_value = 'foo@bar.com'
+        expected = 'Enter only letters, numbers, _ (underscore) or - (hyphen)'
+
+        with self.assertRaises(validators.Invalid) as exc:
+            validator.to_python(invalid_value)
+
+        self.assertEqual(exc.exception.msg, expected)

--- a/formencode/validators.py
+++ b/formencode/validators.py
@@ -556,7 +556,7 @@ class PlainText(Regex):
         >>> PlainText(accept_python=False).from_python('  this  ')
         Traceback (most recent call last):
           ...
-        Invalid: Enter only letters, numbers, or _ (underscore)
+        Invalid: Enter only letters, numbers, _ (underscore) or - (hyphen)
         >>> PlainText(strip=True).to_python('  this  ')
         'this'
         >>> PlainText(strip=True).from_python('  this  ')
@@ -566,7 +566,7 @@ class PlainText(Regex):
     regex = r"^[a-zA-Z_\-0-9]*$"
 
     messages = dict(
-        invalid=_('Enter only letters, numbers, or _ (underscore)'))
+        invalid=_('Enter only letters, numbers, _ (underscore) or - (hyphen)'))
 
 
 class OneOf(FancyValidator):


### PR DESCRIPTION
The hyphen is a valid character in the PlainText validator but it was not informed in the exception message.
I could also change a few of the translation files, but not sure how that process is handled.
