### PR TITLE
Updated postal code format of the Republic of Korea (South Korea).

### DIFF
--- a/formencode/national.py
+++ b/formencode/national.py
@@ -484,7 +484,7 @@ class PostalCodeInCountryFormat(FancyValidator):
         'IS': lambda: DelimitedDigitsPostalCode(3),
         'IT': lambda: DelimitedDigitsPostalCode(5),
         'JP': lambda: DelimitedDigitsPostalCode([3, 4], '-'),
-        'KR': lambda: DelimitedDigitsPostalCode([3, 3], '-'),
+        'KR': lambda: DelimitedDigitsPostalCode(5),
         'LI': FourDigitsPostalCode,
         'LU': FourDigitsPostalCode,
         'MC': lambda: DelimitedDigitsPostalCode(5),


### PR DESCRIPTION
This is in line with announcement 2014-63 by Korea Post. Effective August 1st 2015, the Republic of Korea changed to a 5 digit postal code system. The full announcement can be found on the [website of Korea Post](http://www.koreapost.go.kr/notice/eview.action?contId=e3010000&agencyCode=kpost&order=regDt%20desc&page=1&pagesize=10&notiIdx=24114).

Contributors file is signed (currently on line 61)