### PR TITLE
Update tox.ini and setup.py files for python versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
 
 python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
   - pypy
+  - 2.7
+  - 3.5
+  - 3.6
+#  - 3.7
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 install: pip install .
 

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ from setuptools import setup, find_packages
 
 version = '2.0.0a1'
 
-if not '2.6' <= sys.version < '3.0' and not '3.2' < sys.version:
+if not (2, 7) <= sys.version_info < (3, 0) and not (3, 2) < sys.version_info:
     raise ImportError('Python version not supported')
 
 tests_require = ['nose', 'pycountry',
-    'dnspython' if sys.version < '3.0' else 'dnspython3']
+    'dnspython<=1.16.0' if sys.version_info < (3, 0) else 'dnspython>=1.10.0']
 
 doctests = ['docs/htmlfill.txt', 'docs/Validator.txt',
     'formencode/tests/non_empty.txt']
@@ -32,12 +32,13 @@ setup(name='FormEncode',
            "License :: OSI Approved :: MIT License",
            "Programming Language :: Python",
            "Programming Language :: Python :: 2",
-           "Programming Language :: Python :: 2.6",
            "Programming Language :: Python :: 2.7",
            "Programming Language :: Python :: 3",
            "Programming Language :: Python :: 3.3",
            "Programming Language :: Python :: 3.4",
            "Programming Language :: Python :: 3.5",
+           "Programming Language :: Python :: 3.6",
+           "Programming Language :: Python :: 3.7",
            "Topic :: Software Development :: Libraries :: Python Modules",
            ],
       author='Ian Bicking',

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist=py26,py27,pypy,py33,py34,py35
+envlist=py27,pypy,py35,py36,py37
 
 [testenv]
 deps=
   nose
   wheel
   pycountry
-  py{26,27},pypy: dnspython
-  py{33,34,35}: dnspython3
+  py27,pypy: dnspython<=1.16.0
+  py{35,36,37}: dnspython>=1.10.0
 commands=
   python setup.py clean --all
   python setup.py nosetests


### PR DESCRIPTION
Update the python versions tested in tox file based on https://devguide.python.org/#status-of-python-branches.  Also updated dnspython dependency based on EOL notice for PY27: http://www.dnspython.org/

Removed 3.4 earlier than 2019-03-16 date since it is close.

This should fix https://github.com/formencode/formencode/issues/130 as well