### PR TITLE
Fix invalid escape deprecation warnings

### DIFF
--- a/formencode/national.py
+++ b/formencode/national.py
@@ -388,9 +388,9 @@ class UKPostalCode(Regex):
     """
 
     regex = re.compile(r'^((ASCN|BBND|BIQQ|FIQQ|PCRN|SIQQ|STHL|TDCU|TKCA)'
-        '\s?1ZZ|BFPO (c\/o )?[1-9]{1,4}|GIR\s?0AA|[A-PR-UWYZ]'
-        '([0-9]{1,2}|([A-HK-Y][0-9]|[A-HK-Y][0-9]([0-9]|[ABEHMNPRV-Y]))'
-        '|[0-9][A-HJKS-UW])\s?[0-9][ABD-HJLNP-UW-Z]{2})$', re.I)
+        r'\s?1ZZ|BFPO (c\/o )?[1-9]{1,4}|GIR\s?0AA|[A-PR-UWYZ]'
+        r'([0-9]{1,2}|([A-HK-Y][0-9]|[A-HK-Y][0-9]([0-9]|[ABEHMNPRV-Y]))'
+        r'|[0-9][A-HJKS-UW])\s?[0-9][ABD-HJLNP-UW-Z]{2})$', re.I)
     strip = True
 
     messages = dict(
@@ -646,7 +646,7 @@ class USPhoneNumber(FancyValidator):
     # for emacs: "
 
     _phoneRE = re.compile(r'^\s*(?:1-)?(\d\d\d)[\- \.]?(\d\d\d)[\- \.]?'
-        '(\d\d\d\d)(?:\s*ext\.?\s*(\d+))?\s*$', re.I)
+        r'(\d\d\d\d)(?:\s*ext\.?\s*(\d+))?\s*$', re.I)
 
     messages = dict(
         phoneFormat=_('Please enter a number, with area code,'

--- a/formencode/rewritingparser.py
+++ b/formencode/rewritingparser.py
@@ -48,8 +48,8 @@ class RewritingParser(html_parser.HTMLParser):
             self.listener.reset()
         html_parser.HTMLParser.feed(self, data)
 
-    _entityref_re = re.compile('&([a-zA-Z][-.a-zA-Z\d]*);')
-    _charref_re = re.compile('&#(\d+|[xX][a-fA-F\d]+);')
+    _entityref_re = re.compile(r'&([a-zA-Z][-.a-zA-Z\d]*);')
+    _charref_re = re.compile(r'&#(\d+|[xX][a-fA-F\d]+);')
 
     def unescape(self, s):
         s = self._entityref_re.sub(self._sub_entityref, s)

--- a/formencode/tests/test_declarative.py
+++ b/formencode/tests/test_declarative.py
@@ -34,13 +34,13 @@ class TestDeclarative(unittest.TestCase):
         obj_bar = D(foo='bar')
         obj_baz = D(foo='baz')
         obj = D(bar=obj_bar, baz=obj_baz)
-        self.assertTrue(re.match("<Declarative object \d+"
-            " bar=<Declarative object \d+ foo='bar'>"
-            " baz=<Declarative object \d+ foo='baz'>>", repr(obj)))
+        self.assertTrue(re.match(r"<Declarative object \d+"
+            r" bar=<Declarative object \d+ foo='bar'>"
+            r" baz=<Declarative object \d+ foo='baz'>>", repr(obj)))
 
     def test_repr_recursive(self):
         D = declarative.Declarative
         obj = D(foo='bar')
         obj.bar = obj
-        self.assertTrue(re.match("<Declarative object \d+"
-            " bar=self foo='bar'>", repr(obj)))
+        self.assertTrue(re.match(r"<Declarative object \d+"
+            r" bar=self foo='bar'>", repr(obj)))


### PR DESCRIPTION
In Python 3.6+, invalid escape sequences generate a DeprecationWarning and will become a SyntaxError at some point. This fixes these warnings by explicitly marking the correct strings as raw strings