### PR TITLE
Fix pkg_resources DeprecationWarning

### DIFF
--- a/formencode/api.py
+++ b/formencode/api.py
@@ -32,7 +32,7 @@ def get_localedir():
     # Check the egg first
     if resource_filename is not None:
         try:
-            locale_dir = resource_filename(__name__, "/i18n")
+            locale_dir = resource_filename(__name__, "i18n")
         except NotImplementedError:
             # resource_filename doesn't work with non-egg zip files
             pass


### PR DESCRIPTION
pkg_resources now warns on absolute paths in resource_filename. Because of how resource_filename handles this specific case (discarding the leading '/' because of how it uses split and os.path.joini to construct the actual name), the leading '/' here doesn't actually do anything, so we can remove it without consequence.

Closes #153 