### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10.0 - 3.10.99', '3.11.0-alpha - 3.11.0']
-        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
           # pypy3 on Windows currently fails trying to
           # run dnspython tests. Moving pypy3 to only test linux.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: docs
 init:
-	pip install -e .
+	pip install .
 	pip install -r requirements-test.txt
+
 ci:
 	pytest
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docs
 init:
-	pip install .
+	pip install -e .
 	pip install -r requirements-test.txt
 
 ci:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Libraries :: Python Modules

--- a/src/formencode/__init__.py
+++ b/src/formencode/__init__.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 # formencode package
-from pkg_resources import get_distribution, DistributionNotFound
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    from pkg_resources import get_distribution
+    from pkg_resources import DistributionNotFound as PackageNotFoundError
+    def version(pkg):
+        return get_distribution(__name__).version
 
 from formencode.api import (
     NoDefault, Invalid, Validator, Identity,
@@ -13,7 +19,7 @@ from formencode import national
 from formencode.variabledecode import NestedVariables
 
 try:
-    __version__ = get_distribution(__name__).version
+    __version__ = version(__name__)
 except DistributionNotFound:
      # package is not installed
     __version__ = 'local-test'


### PR DESCRIPTION
This should address the removal of pkg_resources in Python 3.12 as pointed out in https://github.com/TurboGears/Ming/pull/59#issuecomment-1767203104