### PR TITLE
Docs: Fix: `git://` -> `https://`

### DIFF
--- a/docs/community.txt
+++ b/docs/community.txt
@@ -18,7 +18,7 @@ mailing list formencode-cvs@lists.sf.net:
 
 The repository can be checked out with::
 
-    git clone git://github.com/formencode/formencode.git
+    git clone https://github.com/formencode/formencode.git
 
 Note: the SourceForge CVS repository and svn.colorstudy.com Subversion
 repositories and bitbucket Mercurial repositories are out of date and no longer used.

--- a/docs/download.txt
+++ b/docs/download.txt
@@ -6,7 +6,7 @@ Cheese Shop Page <http://cheeseshop.python.org/pypi/FormEncode>`_.
 
 The repository can be checked out with::
 
-    git clone git://github.com/formencode/formencode.git
+    git clone https://github.com/formencode/formencode.git
 
 Or you can download the repository as a zip file from here::
 


### PR DESCRIPTION
`git://` was disabled at GitHub in 2021, see
https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git