### PR TITLE
Fix test automation and automate releases when a tag is pushed

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,88 @@
+name: Publish Python distribution to PyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: python3 -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/FormEncode
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+  github-release:
+    name: >-
+      Sign the Python distribution with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        "$GITHUB_REF_NAME" dist/**
+        --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,14 +13,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         include:
           # pypy3 on Windows currently fails trying to
           # run dnspython tests. Moving pypy3 to only test linux.
-          - python-version: 'pypy-3.9'
+          - python-version: 'pypy3.10'
             os: ubuntu-latest
-          - python-version: 'pypy-3.10'
+          - python-version: '3.7'
+            os: ubuntu-22.04
+          - python-version: '3.7'
+            os: macos-13
+        exclude:
+          - python-version: '3.7'
+            os: macOS-latest
+          - python-version: '3.7'
             os: ubuntu-latest
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,6 @@ flake8:
 coverage:
 	pytest --cov-config .coveragerc --verbose --cov-report term --cov-report xml --cov=formencode formencode
 
-publish:
-	pip install "twine>=4" build
-	python -m build
-	twine upload dist/*
-	rm -fr build dist .egg src/FormEncode.egg-info
-
 .PHONY: docs
 
 docs:

--- a/docs/whatsnew-2.0.txt
+++ b/docs/whatsnew-2.0.txt
@@ -1,8 +1,23 @@
-What's New In FormEncode 2.0
+What's New In FormEncode 2.x
 ============================
 
-This article explains the latest changes in  `FormEncode` version 2.0
+This article explains the latest changes in  `FormEncode` version 2.x
 compared to its predecessor,  `FormEncode` version 1.3.
+
+2.1.1
+-----
+
+ - Add support for 3.13
+ - Don't require `legacy-cgi` to be installed on 3.13 and later
+   (`#176 <https://github.com/formencode/formencode/pull/176>`_)
+ - Don't permit `FieldStorageUploadConverter` to be instantiated without
+   having `legacy-cgi` installed since it does not make sense
+ - Releases are now automated through GitHub Actions
+   (`#184 <https://github.com/formencode/formencode/pull/184>`_)
+
+
+Note: This is the last version that will support Python 3.7 and 3.8 as
+those are now out of support.
 
 2.1.0
 -----
@@ -25,8 +40,8 @@ compared to its predecessor,  `FormEncode` version 1.3.
 2.0.0
 -----
 
- -  `FormEncode` can now run on Python 3.6 and higher without needing to run 2to3 first.
- -  `FormEncode` 2.0 is no longer compatible with Python 2.6 and 3.2 to 3.5.
+ - `FormEncode` can now run on Python 3.6 and higher without needing to run 2to3 first.
+ - `FormEncode` 2.0 is no longer compatible with Python 2.6 and 3.2 to 3.5.
    For compatibility with older Python versions, please use versions < 1.3.
  - This will be the last major version to support Python 2.
  - Add strict flag to ``USPostalCode`` to raise error on postal codes that has too

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Libraries :: Python Modules

--- a/src/formencode/validators.py
+++ b/src/formencode/validators.py
@@ -1773,7 +1773,19 @@ class FieldStorageUploadConverter(FancyValidator):
     This doesn't do any conversion, but it can detect empty upload
     fields (which appear like normal fields, but have no filename when
     no upload was given).
+
+    Requires the legacy-cgi package on Python 3.13 and later.
     """
+
+    def __init__(self, *args, **kw):
+        if cgi is None:
+            warnings.warn(
+                "legacy-cgi <https://pypi.org/project/legacy-cgi/> is not"
+                "  installed on your system (or the cgi package cannot be"
+                " found). I cannot convert FieldStorage")
+            raise ImportError("no module named cgi")
+        super().__init__(*args, **kw)
+
     def _convert_to_python(self, value, state=None):
         if cgi and isinstance(value, cgi.FieldStorage):
             if getattr(value, 'filename', None):
@@ -1819,6 +1831,9 @@ class FileUploadKeeper(FancyValidator):
 
     Note that big file uploads mean big hidden fields, and lots of
     bytes passed back and forth in the case of an error.
+
+    Note: requires the legacy-cgi package on Python 3.13 and later to be able to handle
+    ``cgi.FieldStorage`` values.
     """
 
     upload_key = 'upload'

--- a/src/formencode/validators.py
+++ b/src/formencode/validators.py
@@ -1397,7 +1397,7 @@ class URL(FancyValidator):
         Traceback (most recent call last):
             ...
         Invalid: You must start your URL with http://, https://, etc
-        >>> u.to_python('http://www.formencode.org/does/not/exist/page.html')
+        >>> u.to_python('https://httpbin.org/status/404')
         Traceback (most recent call last):
             ...
         Invalid: The server responded that the page could not be found
@@ -1660,7 +1660,7 @@ class XRI(FancyValidator):
         if value.startswith('xri://'):
             value = value[6:]
 
-        if not value[0] in ('@', '=') and not (
+        if value[0] not in ('@', '=') and not (
                 self.xri_type == 'i-number' and value[0] == '!'):
             raise Invalid(self.message('noType', state), value, state)
 


### PR DESCRIPTION
This fixes tests on Github that are failing for several reasons:
- Python 3.7 is not supported on the latest Ubuntu and MacOS images
- The URL doctest is failing on a redirect from http to https

It also adds automation to publish to pypi when a tag is pushed.